### PR TITLE
fix: update Dockerfile and docker-compose.yml for PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:php8.2-alpine
+FROM dunglas/frankenphp:php8.3-alpine
 
 RUN install-php-extensions \
     ctype \
@@ -20,15 +20,17 @@ RUN install-php-extensions \
     session \
     tokenizer \
     xml \
-    zip
+    zip \
+    @composer 
 
-RUN apk add --no-cache nodejs npm
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    php composer-setup.php && \
-    php -r "unlink('composer-setup.php');" && \
-    mv composer.phar /usr/local/bin/composer
+WORKDIR /app
 
 COPY . /app
 
-ENTRYPOINT ["php", "artisan", "octane:frankenphp"]
+RUN composer install --optimize-autoloader
+
+RUN php artisan optimize
+
+ENTRYPOINT ["php"]
+
+CMD ["artisan", "octane:frankenphp", "--workers=1", "--max-requests=1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ services:
     build:
       context: .
     ports:
-      - "8008:8000"
+      - "${APP_PORT}:8000"
     volumes:
-      - .:/app
+      - ./.env:/app/.env
     restart: unless-stopped
-    entrypoint: >
-      sh -c "composer install && npm i && npm run build && exec php artisan octane:frankenphp --workers=1 --max-requests=1"


### PR DESCRIPTION
This pull request includes updates to the Docker configuration and the `docker-compose.yml` file to improve the development environment and streamline the build process. The most important changes include upgrading the PHP version, modifying the Dockerfile to optimize the autoloader and artisan commands, and updating the `docker-compose.yml` file to use environment variables and simplify the volume mounting.

Updates to Docker configuration:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Upgraded the PHP version from 8.2 to 8.3.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R36): Added `@composer` to the list of PHP extensions and removed manual Composer installation steps.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R36): Changed the entrypoint and command to optimize the autoloader and run artisan commands with specific options.

Updates to `docker-compose.yml`:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-L11): Replaced the hardcoded port with an environment variable `${APP_PORT}` for better flexibility.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L6-L11): Simplified volume mounting by mapping the `.env` file directly.