### PR TITLE
Handle null order case in result and report calculations

### DIFF
--- a/app/Models/OrderProduct.php
+++ b/app/Models/OrderProduct.php
@@ -22,6 +22,10 @@ class OrderProduct extends Model
         $printedCountArray = [];
         $orderProduct = $this;
 
+        if (! $orderProduct->order) {
+            return 0;
+        }
+
         foreach ($orderProduct->order->spks as $spk) {
 
             $spkProducts = $spk->spkProducts()
@@ -51,6 +55,10 @@ class OrderProduct extends Model
     {
         $printedCountArray = [];
         $orderProduct = $this;
+
+        if (! $orderProduct->order) {
+            return 0;
+        }
 
         foreach ($orderProduct->order->spks as $spk) {
 
@@ -113,6 +121,10 @@ class OrderProduct extends Model
         $spkProductArray = [];
         $orderProduct = $this;
 
+        if (! $orderProduct->order) {
+            return false;
+        }
+
         foreach ($orderProduct->order->spks as $spk) {
             foreach ($spk->spkProducts as $spkProduct) {
                 foreach ($spkProduct->order_products as $orderProduct) {
@@ -153,6 +165,10 @@ class OrderProduct extends Model
     {
         $reportedProductArray = [];
         $orderProduct = $this;
+
+        if (! $orderProduct->order) {
+            return false;
+        }
 
         foreach ($orderProduct->order->spks as $spk) {
 


### PR DESCRIPTION
This pull request improves the robustness of several methods in the `OrderProduct` model by adding checks to ensure that the associated `order` exists before attempting to access its properties. This helps prevent potential errors when `order` is null.

Error prevention and robustness improvements in `OrderProduct`:

* Added an early return of `0` in `getResultAttribute()` if `order` is missing, preventing null reference errors.
* Added an early return of `0` in `getRawResultAttribute()` if `order` is missing.
* Modified `hasSpkProducts()` to return `false` if `order` is missing.
* Modified `hasReport()` to return `false` if `order` is missing.