### PR TITLE
Add trashed filter to order table

### DIFF
--- a/app/Filament/Admin/Resources/OrderResource.php
+++ b/app/Filament/Admin/Resources/OrderResource.php
@@ -371,6 +371,7 @@ class OrderResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
+                Tables\Filters\TrashedFilter::make(),
                 Tables\Filters\Filter::make('semester')
                     ->label('Semester')
                     ->form([


### PR DESCRIPTION
This pull request adds a new filter to the orders table in the admin panel, allowing users to filter by trashed (soft-deleted) records.

Filtering improvements:

* Added `TrashedFilter` to the table filters in `OrderResource.php`, enabling filtering for soft-deleted orders.